### PR TITLE
feat: add ICMP type aliases and modify service Range operator

### DIFF
--- a/cisco_config/asa/common/command/object_group/service/__init__.py
+++ b/cisco_config/asa/common/command/object_group/service/__init__.py
@@ -2,6 +2,7 @@ from typing import Optional, Literal, Union
 from typing_extensions import TypeAlias
 
 from ......command import Command, Key, Subcommand
+from ... import description
 from . import object
 
 
@@ -26,3 +27,4 @@ class ServiceObjectGroup(Command):
     name: str
     protocol: Optional[Literal["tcp", "udp", "tcp-udp"]] = None
     children: Subcommand[ServiceObjectGroupChild]
+    description: Subcommand[description.ModifyDescription]

--- a/cisco_config/asa/common/dsl/icmp.py
+++ b/cisco_config/asa/common/dsl/icmp.py
@@ -11,7 +11,27 @@ __all__ = (
 
 
 IcmpType: TypeAlias = Union[
-    Literal["echo", "echo-reply"],
+    Literal[
+        "alternate-address",
+        "conversion-error",
+        "echo",
+        "echo-reply",
+        "information-reply",
+        "information-request",
+        "mask-reply",
+        "mask-request",
+        "mobile-redirect",
+        "parameter-problem",
+        "redirect",
+        "router-advertisement",
+        "router-solicitation",
+        "source-quench",
+        "time-exceeded",
+        "timestamp-reply",
+        "timestamp-request",
+        "traceroute",
+        "unreachable"
+    ],
     int
 ]
 

--- a/cisco_config/asa/common/dsl/op.py
+++ b/cisco_config/asa/common/dsl/op.py
@@ -38,8 +38,8 @@ class Neq(BaseModel):
 
 class Range(BaseModel):
     key: Key["range"]
-    start: int
-    stop: int
+    start: Union[int, str]
+    stop: Union[int, str]
 
 
 Op: TypeAlias = Union[Eq, Gt, Lt, Neq, Range]

--- a/tests/asa.conf
+++ b/tests/asa.conf
@@ -122,6 +122,8 @@ object network NET_192.177.0.0_16
  subnet 192.177.0.0 255.255.0.0
 object service 3660
  service tcp destination eq 3660
+object service SRV01
+ service tcp destination range www https
 object-group network VPN_Test2
  network-object object NET_192.169.0.0_16
  network-object object NET_192.170.0.0_16

--- a/tests/test_asa.py
+++ b/tests/test_asa.py
@@ -390,6 +390,23 @@ from cisco_config.asa.common import command, dsl
                         )
                     ]
                 ),
+                command.object.service.ServiceObject(
+                    name="SRV01",
+                    target=[
+                        command.object.service.service.Service(
+                            spec=command.object.service.service.L4ServiceSpec(
+                                protocol="tcp",
+                                destination=(
+                                    "destination",
+                                    dsl.op.Range(
+                                        start="www",
+                                        stop="https"
+                                    )
+                                )
+                            )
+                        )
+                    ]
+                ),
                 command.object_group.network.NetworkObjectGroup(
                     name="VPN_Test2",
                     children=[


### PR DESCRIPTION
- extended ICMP type aliases.
- added a possibility to use service range objects not only with service numbers but also with service names.